### PR TITLE
Update superagent's version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
       "wechall": "bin/cmd.js"
   },
   "dependencies": {
-    "superagent": "~0.16.0",
+    "superagent": ">3.6.3",
     "cli-color": "~0.2.3",
     "nomnom": "~1.6.2"
   },


### PR DESCRIPTION
- a ZIP bomb vulnerability exists with superagent versions up to 3.6.3